### PR TITLE
Fixed dead link for broadcasting documentation

### DIFF
--- a/notebooks/numpy.ipynb
+++ b/notebooks/numpy.ipynb
@@ -1981,7 +1981,7 @@
    "source": [
     "# Broadcasting\n",
     "\n",
-    "A very powerful mechanism of NumPy arrays is [broadcasting](https://docs.scipy.org/doc/numpy-dev/user/basics.broadcasting.html).\n",
+    "A very powerful mechanism of NumPy arrays is [broadcasting](https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html).\n",
     "Broadcasting is used when an operation is used on two arrays of different shapes.\n",
     "The rules are:\n",
     "\n",


### PR DESCRIPTION
Previous link returned 404 when entered.
Replaced by `/numpy/` which displays the latest stable version docs.