### PR TITLE
maybe-a-fix

### DIFF
--- a/notebooks/gillespie.ipynb
+++ b/notebooks/gillespie.ipynb
@@ -411,7 +411,7 @@
     "@numba.jit # 2-fold faster\n",
     "def draw_time(rates):\n",
     "    total_rate = rates.sum()\n",
-    "    return np.random.exponential(1/total_rate)"
+    "    return np.random.exponential(total_rate)"
    ]
   },
   {


### PR DESCRIPTION
np.random.exponential uses 1/scale as its gamma (exponential distribution parameter). Doc:
https://docs.scipy.org/doc/numpy/reference/generated/numpy.random.exponential.html